### PR TITLE
Configure setup the modern way

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,33 @@
+[metadata]
+name = emojiflag
+version = 1.0.3
+description = Emoji country flags for language codes and LCID's
+long_description = file: README.rst
+url = https://github.com/lotrekagency/emojiflag
+license = MIT
+author = Lotrek
+author_email = dimmitutto@lotrek.it
+keywords = emoji, unicode, flag, locale
+classifiers =
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+
+[options]
+zip_safe = False
+packages =
+    emojiflag
+
+[bdist_wheel]
+universal=0
+
+[tool:pytest]
+addopts =
+    --cov
+
+[coverage:run]
+branch = True
+source = emojiflag
+
+[coverage:report]
+ignore_errors = True
+show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-
-setup(name='emojiflag',
-	version='1.0.2',
-	url='https://github.com/lotrekagency/emojiflag',
-	license='MIT',
-	author='Lotrek',
-	author_email='dimmitutto@lotrek.it',
-	description='Emoji country flags for language codes and LCID\'s',
-	long_description=open('README.rst').read(),
-	install_requires=[],
-	packages=find_packages(),
-    include_package_data=True,
-    classifiers=[
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3'
-    ]
-)
+setup()


### PR DESCRIPTION
Configuring `setuptools` with function arguments [is deprecated](https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files).
The modern way to setup is `setup.cfg`.
In the future `setup.cfg` should be renamed to `pyproject.toml` and `setup.py` should be removed completely. See [PEP-518](https://www.python.org/dev/peps/pep-0518/).